### PR TITLE
Command line echo text fix

### DIFF
--- a/phala_quick_install.sh
+++ b/phala_quick_install.sh
@@ -71,7 +71,9 @@ else
     read answer
     if [ "$answer" != "${answer#[Yy]}" ] ;then 
     echo Yes
-    echo -n "1. In a seperate shell on same host enter 'curl https://sh.rustup.rs -sSf | sh'\n2.When installation is complete enter 'source ~/.cargo/env'\nPress any key to continue when done" 
+    echo "1. In a seperate shell on same host enter 'curl https://sh.rustup.rs -sSf | sh'"
+    echo "2. When installation is complete enter 'source ~/.cargo/env'"
+    echo "Press any key to continue when done" 
     while [ true ] ; do
     read KEYTYPE
     if [ $? = 0 ] ; then


### PR DESCRIPTION
The current "echo -n ..." results in 1 unreadable single line cmd output:
<img width="960" alt="截屏2022-01-02 上午5 51 00" src="https://user-images.githubusercontent.com/711926/147861009-2813acec-fa1f-41ba-a88c-6e880a37ae46.png">

